### PR TITLE
Fix calendar localized week before translations

### DIFF
--- a/src/locale/de.js
+++ b/src/locale/de.js
@@ -3,7 +3,7 @@ const calendar = {
 	nextDay: '[Morgen], LT',
 	nextWeek: '[Nächster] dddd, LT',
 	lastDay: '[Gestern], LT',
-	lastWeek: 'dddd, LT',
+	lastWeek: '[Letzter] dddd, LT',
 	sameElse: 'L, LT'
 };
 

--- a/src/locale/en.js
+++ b/src/locale/en.js
@@ -3,7 +3,7 @@ const calendar = {
 	nextDay: '[Tomorrow], LT',
 	nextWeek: '[Next] dddd, LT',
 	lastDay: '[Yesterday], LT',
-	lastWeek: 'dddd, LT',
+	lastWeek: '[Last] dddd, LT',
 	sameElse: 'L, LT'
 };
 

--- a/src/locale/es.js
+++ b/src/locale/es.js
@@ -1,22 +1,22 @@
 const calendar = {
-    sameDay: 'LT',
-    nextDay: '[Mañana], LT',
-    nextWeek: '[Siguiente] dddd, LT',
-    lastDay: '[Ayer], LT',
-    lastWeek: 'dddd, LT',
-    sameElse: 'L, LT'
+	sameDay: 'LT',
+	nextDay: '[Mañana], LT',
+	nextWeek: '[Siguiente] dddd, LT',
+	lastDay: '[Ayer], LT',
+	lastWeek: '[Pasado] dddd, LT',
+	sameElse: 'L, LT'
 };
 
 const relative = {
-    future: 'en %s',
-    past: 'hace %s',
-    s: 'menos de un minuto',
-    m: 'minuto',
-    mm: 'minutos',
-    h: 'hora',
-    hh: 'horas',
-    d: 'día',
-    dd: 'días'
+	future: 'en %s',
+	past: 'hace %s',
+	s: 'menos de un minuto',
+	m: 'minuto',
+	mm: 'minutos',
+	h: 'hora',
+	hh: 'horas',
+	d: 'día',
+	dd: 'días'
 };
 
 export default { calendar, relative };

--- a/src/locale/fr.js
+++ b/src/locale/fr.js
@@ -1,9 +1,9 @@
 const calendar = {
 	sameDay: 'LT',
 	nextDay: '[Demain], LT',
-	nextWeek: 'dddd [Prochain], LT',
+	nextWeek: 'dddd [prochain], LT',
 	lastDay: '[Hier], LT',
-	lastWeek: 'dddd, LT',
+	lastWeek: 'dddd [dernier], LT',
 	sameElse: 'L LT'
 };
 


### PR DESCRIPTION
The `lastWeek` case was missing the localized "last" translation.